### PR TITLE
Fix `spineTo` returning no trees in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ cabal.project.local~
 .HTF/
 .ghc.environment.*
 stack.yaml.lock
-*.cabal

--- a/duplo.cabal
+++ b/duplo.cabal
@@ -1,0 +1,36 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 3fad7e4a3021371fb1d3737f6267eaf5f538392ba22884ebd53a5a333c54d681
+
+name:           duplo
+version:        0.0.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Duplo
+      Duplo.Error
+      Duplo.Example
+      Duplo.Lattice
+      Duplo.Pretty
+      Duplo.Tree
+  other-modules:
+      Paths_duplo
+  hs-source-dirs:
+      src/
+  default-extensions: AllowAmbiguousTypes ApplicativeDo BangPatterns BlockArguments ConstraintKinds DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveTraversable DerivingStrategies DerivingVia EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralisedNewtypeDeriving LambdaCase MagicHash MultiParamTypeClasses NamedFieldPuns OverloadedStrings QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators UndecidableInstances ViewPatterns
+  ghc-options: -freverse-errors -Wall -threaded
+  build-depends:
+      base
+    , comonad
+    , exceptions
+    , fastsum
+    , free
+    , pretty
+    , text
+    , transformers
+  default-language: Haskell2010

--- a/src/Duplo/Tree.hs
+++ b/src/Duplo/Tree.hs
@@ -50,7 +50,6 @@ module Duplo.Tree
 import Control.Applicative
 import Control.Comonad
 import Control.Comonad.Cofree
-import Control.Monad
 import Control.Monad.Catch
 
 import Data.Foldable
@@ -241,18 +240,13 @@ loop' f = return . go
 
 {- | Construct a sequence of trees, covering given point, bottom-up. -}
 spineTo :: (Apply Foldable fs, Lattice i) => (i -> Bool) -> Tree fs i -> [Tree fs i]
-spineTo covers tree =
-  case go [] tree of
-    x : _ -> x
-    []    -> []
+spineTo doesCover = go []
   where
-    go acc tree'@(i' :< (toList -> trees)) = do
-      unless (covers i') do
-        fail ""
-
-      if null trees
-      then do return (tree' : acc)
-      else do go     (tree' : acc) =<< trees
+    go acc branch@(info :< (toList -> children))
+      | doesCover info = case concatMap (go (branch : acc)) children of
+          [] -> branch : acc
+          deeperRes -> deeperRes
+      | otherwise = []
 
 -- | Locate the point and attepmt update on spine up from that point.
 findAndUpdateFrom


### PR DESCRIPTION
Problem: if the given interval is inside the root interval but is not
    covered by any of the leaf intervals, `spineTo` would return an
    empty list, which is incorrect. This list should contain at least
    the root node.

Solution: gather results from all children (assuming that their
     intervals are disjunct), if the resulting set is empty, stop
     descent, return trees gathered by now.

Also, add a cabal file, otherwise it very much irritates `stack
     build`. It's a manner of good taste as well.