### PR TITLE
Get rid of tail recursion in `spineTo`

### DIFF
--- a/src/Duplo/Tree.hs
+++ b/src/Duplo/Tree.hs
@@ -240,12 +240,10 @@ loop' f = return . go
 
 {- | Construct a sequence of trees, covering given point, bottom-up. -}
 spineTo :: (Apply Foldable fs, Lattice i) => (i -> Bool) -> Tree fs i -> [Tree fs i]
-spineTo doesCover = go []
+spineTo doesCover = reverse . go
   where
-    go acc branch@(info :< (toList -> children))
-      | doesCover info = case concatMap (go (branch : acc)) children of
-          [] -> branch : acc
-          deeperRes -> deeperRes
+    go branch@(info :< children)
+      | doesCover info = branch : concatMap go children
       | otherwise = []
 
 -- | Locate the point and attepmt update on spine up from that point.


### PR DESCRIPTION
This is a follow up to #1.

While reviewing it, I couldn’t help but notice that the way its return value is structured, there seemed to be no reason to try to make it tail-recursive, so I simply rewrote it directly.

Sadly, there are no tests to verify that my rewrite is equivalent, but, I hope, it is.

It might be that I misunderstood something, and there actually was a reason to implemented it in a tail-recursive way, please let me know if it was the case.