### PR TITLE
[LIGO-405] Fix a regression caused by LIGO-382

### DIFF
--- a/duplo.cabal
+++ b/duplo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aeca302abc8a2fb6b027654905f9be63b5cff5372e6b1fa6e24c8c5048e1098e
+-- hash: 62829fa79e51b5498bfc95d5618f3179e24d0079915c15c13b70520d82c86d6c
 
 name:           duplo
 version:        0.0.0
@@ -59,9 +59,9 @@ library
   build-depends:
       base
     , comonad
+    , exceptions
     , fastsum
     , free
     , pretty
     , text
-    , transformers
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -3,11 +3,11 @@ name: duplo
 dependencies:
   - base
   - comonad
+  - exceptions
   - fastsum
   - free
   - pretty
   - text
-  - transformers
 
 default-extensions:
   - AllowAmbiguousTypes

--- a/src/Duplo/Tree.hs
+++ b/src/Duplo/Tree.hs
@@ -53,12 +53,10 @@ import Control.Applicative
 import Control.Comonad
 import Control.Comonad.Cofree
 import Control.Exception (Exception (..), throwIO)
-import Control.Monad (liftM)
+import Control.Monad.Catch (MonadCatch (catch), MonadThrow (throwM))
 import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
 
 import Data.Foldable
-import Data.Function ((&))
 import Data.Maybe
 import Data.Sum
 
@@ -99,19 +97,19 @@ data Descent fs gs a b m where
     => DescentHandler f g a b fs m  -- ^ 1-layer transformation
     -> Descent fs gs a b m
 
-type DescentHandler f g a b fs m
-  = a -> f (Tree fs a) -> ExceptT HandlerFailed m (b, g (Tree fs a))
+type DescentHandler f g a b fs m = a -> f (Tree fs a) -> m (b, g (Tree fs a))
 type DescentDefault fs gs a b m
   =  (Tree fs a -> m (Tree gs b))
   ->  Tree fs a -> m (Tree gs b)
 
 data HandlerFailed = HandlerFailed
   deriving stock Show
+  deriving anyclass Exception
 
 {- | Reconstruct the tree top-down. -}
 descent
   :: forall a b fs gs m
-  .  Monad m
+  .  MonadCatch m
   => DescentDefault fs gs a b m  -- ^ The default handler
   -> [Descent fs gs a b m]  -- ^ The concrete handlers for chosen nodes
   -> Tree fs a  -- ^ The tree to ascent.
@@ -123,11 +121,10 @@ descent fallback transforms = restart
 
     go :: [Descent fs gs a b m] -> Tree fs a -> m (Tree gs b)
     go (Descent handler : rest) tree = do
-      let recover = go rest tree
-      match tree & maybe recover \(i, f) ->
-        runExceptT (handler i f) >>= \case
-          Left HandlerFailed -> recover
-          Right (i', f') -> fastMake i' <$> traverse restart f'
+        (i,  f)  <- matchOrFail tree
+        (i', f') <- handler i f
+        fastMake i' <$> traverse restart f'
+      `catch` \HandlerFailed -> go rest tree
 
     go [] tree = do
       fallback restart tree
@@ -180,11 +177,11 @@ data Visit fs a m where
     => VisitHandler f a fs m  -- ^ 1-layer transformation
     -> Visit fs a m
 
-type VisitHandler f a fs m = a -> f (Tree fs a) -> ExceptT HandlerFailed m ()
+type VisitHandler f a fs m = a -> f (Tree fs a) -> m ()
 
 visit
   :: forall a fs m
-  .  (Monad m, Apply Foldable fs)
+  .  (MonadCatch m, Apply Foldable fs)
   => [Visit fs a m]  -- ^ The concrete handlers for chosen nodes.
   -> Tree fs a  -- ^ The tree to ascent.
   -> m ()
@@ -193,11 +190,11 @@ visit visitors = restart
     restart = go visitors
 
     go (Visit handler : rest) tree = do
-      let recover = go rest tree
-      match tree & maybe recover \(a, f) ->
-        runExceptT (handler a f) >>= \case
-          Left HandlerFailed -> recover
-          Right () -> for_ f restart
+        (a, f) <- matchOrFail tree
+        handler a f
+        for_ f restart
+      `catch` \HandlerFailed -> go rest tree
+
     go [] (_ :< f) = do
       for_ f restart
 
@@ -243,6 +240,10 @@ match (i :< f) = do
   f' <- project f
   return (i, f')
 {-# INLINE match #-}
+
+matchOrFail :: (Element f fs, MonadThrow m) => Tree fs i -> m (i, f (Tree fs i))
+matchOrFail = maybe (throwM HandlerFailed) pure . match
+{-# INLINE matchOrFail #-}
 
 {- | Attempt extraction of node from current root. -}
 layer :: Element f fs => Tree fs i -> Maybe (f (Tree fs i))
@@ -320,7 +321,7 @@ skip = pure ()
 usingScope
   :: forall a b fs gs m
   .  ( Monad m
-     , Apply (Scoped a (ExceptT HandlerFailed m) (Tree fs a)) fs
+     , Apply (Scoped a m (Tree fs a)) fs
      )
   => Descent fs gs a b m
   -> Descent fs gs a b m
@@ -328,9 +329,9 @@ usingScope (Descent action) = Descent \a f -> do
   -- So. To unpack `Apply X fs` constraint to get `X f`, ypu do `apply :: (forall g. c g => g a -> b) -> Sum fs a -> b`.
   -- The problem is, we have `f a`, not `Sum fs a`. Which I clutch up here by calling `inject @_ @fs f`.
   let injected = inject @_ @fs f
-  apply @(Scoped a (ExceptT HandlerFailed m) (Tree fs a)) (before a) injected
-  res <- action a f `finallyE`
-    apply @(Scoped a (ExceptT HandlerFailed m) (Tree fs a)) (after a) injected
+  apply @(Scoped a m (Tree fs a)) (before a) injected
+  res <- action a f
+  apply @(Scoped a m (Tree fs a)) (after a) injected
   return res
 {-# INLINE usingScope #-}
 
@@ -380,18 +381,3 @@ collect tree@(_ :< f) =
     case match tree of
       Just it -> [it]
       Nothing -> []
-
--- TODO: transformers 0.5.6.2, which is used in duplo, does not yet define such
--- functions, present in transformers 0.6.0.2. We define them here instead. Once
--- duplo is updated and uses a more recent version of transformers, consider
--- removing `tryE` and `finallyE`.
-tryE :: Monad m => ExceptT e m a -> ExceptT e m (Either e a)
-tryE m = catchE (liftM Right m) (return . Left)
-{-# INLINE tryE #-}
-
-finallyE :: Monad m => ExceptT e m a -> ExceptT e m () -> ExceptT e m a
-finallyE m closer = do
-  res <- tryE m
-  closer
-  either throwE return res
-{-# INLINE finallyE #-}


### PR DESCRIPTION
In LIGO-382, we accidentally changed the semantics of `descent`. When an error from `IO` is raised, it works differently from using `ExceptT` when we have a monadic stack, as the state is still propagated, rather than discarded. We still wish to discard it. This PR pretty much undoes some of the changes made previously to fix this regression and adds "pure" variants for functions that don't wish to have a `MonadCatch` constraint.